### PR TITLE
Update README.md with composer tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The goals of this implementation is to follow the IPP specification as closely a
 The easiest way is to use composer and add obray/IPP to the require section:
 ```JSON
 "require": {
-    "obray/IPP": "dev-master"
+    "obray/ipp": "dev-master",
+    "obray/http": "dev-master"
 }
 ```
 


### PR DESCRIPTION
1.) Composer doesn't accept upper case for the package name, as in "obray/IPP". Making it "obray/ipp" works.
2.) Because dependent package "obray/http" will also not meet most users' minimum stability, it should also be explicitly included, with a version of "dev-master"