### PR TITLE
Fix after external library removal

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -47,13 +47,13 @@ class Request implements \obray\ipp\interfaces\RequestInterface
 
         $server_output = curl_exec($ch);
 
-        curl_close ($ch);
-
         if(curl_errno($ch)) throw new \Exception(curl_error($ch));
         $info = curl_getinfo($ch);
+        
+        curl_close($ch);
 
         if($info['http_code'] == 401) throw new \obray\ipp\exceptions\AuthenticationError();
-        if($info['http_code'] != 200) throw new \obray\ipp\exceptions\HTTPError('http_code');
+        if($info['http_code'] != 200) throw new \obray\ipp\exceptions\HTTPError($info['http_code']);
 
         // Further processing ...
         $responsePayload = new \obray\ipp\transport\IPPPayload();


### PR DESCRIPTION
Curl_close must be called after `curl_errno()` and `curl_getinfo` `url_errno(): supplied resource is not a valid cURL handle resource` and
Incorrect exception contructor `Wrong parameters for obray\ipp\exceptions\HTTPError([string $message [, long $code [, Throwable $previous = NULL]]])`