### PR TITLE
AttributeGroup optional parameter before required

### DIFF
--- a/src/AttributeGroup.php
+++ b/src/AttributeGroup.php
@@ -81,7 +81,9 @@ abstract class AttributeGroup implements \JsonSerializable
 
     protected function decodeAttributes($binary, &$offset, $validAttributeGroupTags, $endOfAttributesTag, &$attributes)
     {
-        $offset = 8;
+        if (!isset($offset)) {
+            $offset = 8;
+        }
         while(true){
             
             $attribute = (new \obray\ipp\Attribute(!empty($attributeName)?$attributeName:NULL))->decode($binary, $offset);

--- a/src/AttributeGroup.php
+++ b/src/AttributeGroup.php
@@ -79,8 +79,9 @@ abstract class AttributeGroup implements \JsonSerializable
         return $this->decodeAttributes($binary, $offset, $validAttributeGroupTags, $endOfAttributesTag, $this->attributes);
     }
 
-    protected function decodeAttributes($binary, &$offset=8, $validAttributeGroupTags, $endOfAttributesTag, &$attributes)
+    protected function decodeAttributes($binary, &$offset, $validAttributeGroupTags, $endOfAttributesTag, &$attributes)
     {
+        $offset = 8;
         while(true){
             
             $attribute = (new \obray\ipp\Attribute(!empty($attributeName)?$attributeName:NULL))->decode($binary, $offset);


### PR DESCRIPTION
PHP 8.1 throws deprecated notice:
`Optional parameter $offset declared before required parameter $attributes is implicitly treated as a required parameter`