### PR TITLE
Add has() method to AttributeGroup

### DIFF
--- a/src/AttributeGroup.php
+++ b/src/AttributeGroup.php
@@ -49,6 +49,19 @@ abstract class AttributeGroup implements \JsonSerializable
     }
 
     /**
+     * Has
+     *
+     * Returns true if the attribute exists and is non-empty, false otherwise
+     *
+     * @param string $name - the name of the attribute to check for
+     */
+
+    public function has(string $name)
+    {
+        return (array_key_exists($name,$this->attributes) && !empty($this->attributes[$name]));
+    }
+
+    /**
      * Encode
      * 
      * Encodes the attribute group according to RFC8010 secion 3.1.2

--- a/test/AttributeGroupTest.php
+++ b/test/AttributeGroupTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace obray\ipp\test;
+
+use obray\ipp\AttributeGroup;
+use obray\ipp\types\Integer;
+use PHPUnit\Framework\TestCase;
+
+class TestAttributes extends AttributeGroup{
+
+    public function set(string $name, $value): void
+    {
+        $this->attributes[$name] = $value;
+    }
+}
+
+class AttributeGroupTest extends TestCase
+{
+
+    private ?TestAttributes $testAttributes = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testAttributes = new TestAttributes();
+        $this->testAttributes->set('test',new Integer(255));
+        $this->testAttributes->set('empty','');
+
+    }
+
+    public function testHas() {
+
+        $this->assertTrue($this->testAttributes->has('test'));
+        $this->assertFalse($this->testAttributes->has('non-existent'));
+        $this->assertFalse($this->testAttributes->has('empty'));
+
+    }
+}


### PR DESCRIPTION
When a user attempts to retrieve an empty or non-existent attribute from an attribute group an exception is thrown. Without a way to easily test the presence of the attribute users are stuck with catching the exception (or not!) to find out the attribute isn't set. 

By adding this simple method to the abstract class all attribute groups will have an easy way to check.