### PR TITLE
Bugfix: job-state-reasons case was missing

### DIFF
--- a/src/JobAttributes.php
+++ b/src/JobAttributes.php
@@ -21,7 +21,7 @@ class JobAttributes extends \obray\ipp\AttributeGroup
             case 'job-state':
                 $this->attributes[$name] = new \obray\ipp\Attribute('job-state', $value, \obray\ipp\enums\Types::ENUM);
                 break;
-            case 'job-state':
+            case 'job-state-reasons':
                 $this->attributes[$name] = new \obray\ipp\Attribute('job-state-reasons', $value, \obray\ipp\enums\Types::KEYWORD);
                 break;
             case 'job-state-message':

--- a/test/JobAttributesTest.php
+++ b/test/JobAttributesTest.php
@@ -8,4 +8,14 @@ class JobAttributeTest extends TestCase
     {
         $this->assertSame(1, 1);
     }
+
+    public function testJobStateReasonsCanBeSet() {
+
+        $jobAttributes = new \obray\ipp\JobAttributes();
+        $jobAttributes->set('job-state-reasons',new \obray\ipp\enums\JobStateReasons(\obray\ipp\enums\JobStateReasons::jobIncoming));
+
+        $this->assertEquals('jobincoming',(string) $jobAttributes->{'job-state-reasons'});
+
+    }
+
 }


### PR DESCRIPTION
There was a minor error in JobAttributes where the case for job-state was duplicated and the case for job-state-reasons was absent. I'm assuming copy and paste got someone. Anyway, it's fixed.