### PR TITLE
Allow all JobAttributes to be set by array

### DIFF
--- a/src/JobAttributes.php
+++ b/src/JobAttributes.php
@@ -2,9 +2,45 @@
 
 namespace obray\ipp;
 
+use obray\ipp\types\RangeOfInteger;
+
 class JobAttributes extends \obray\ipp\AttributeGroup
 {
     protected $attribute_group_tag = 0x02;
+
+    /**
+     * __construct
+     *
+     * Allows pre-setting the JobAttributes from an associative array of attributes in the form name => value.
+     *
+     * For example to preset page-ranges to the first 2 pages only:
+     *
+     * $attributeArray = [
+     *  'page-ranges' => '1-2'
+     * ]
+     *
+     * @param array|null $attributeArray
+     */
+    public function __construct(?array $attributeArray = null)
+    {
+
+        if (is_array($attributeArray)) {
+
+            foreach ($attributeArray as $name => $value) {
+
+                try {
+                    $this->set($name,$value);
+                } catch (\Exception) {
+                    continue;
+                }
+
+            }
+
+        }
+
+    }
+
+
     /**
      * Set
      * Defines the attributes that can be set on the Job Attribute Group.

--- a/src/JobAttributes.php
+++ b/src/JobAttributes.php
@@ -2,8 +2,6 @@
 
 namespace obray\ipp;
 
-use obray\ipp\types\RangeOfInteger;
-
 class JobAttributes extends \obray\ipp\AttributeGroup
 {
     protected $attribute_group_tag = 0x02;

--- a/src/JobAttributes.php
+++ b/src/JobAttributes.php
@@ -30,7 +30,8 @@ class JobAttributes extends \obray\ipp\AttributeGroup
 
                 try {
                     $this->set($name,$value);
-                } catch (\Exception) {
+                } catch (\Exception $e) {
+                    // Skip any invalid attributes when instantiating from an array
                     continue;
                 }
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -49,13 +49,7 @@ class Printer
 
         $jobAttributes = NULL;
         if(!empty($attributes)){
-            $jobAttributes = new \obray\ipp\JobAttributes();
-        }
-        if(!empty($attributes['media'])){
-        	$jobAttributes->{'media'} = $attributes['media'];
-        }
-        if(!empty($attributes['media-col'])){
-            $jobAttributes->{'media-col'} = $attributes['media-col'];
+            $jobAttributes = new \obray\ipp\JobAttributes($attributes);
         }
 
         $payload = new \obray\ipp\transport\IPPPayload(

--- a/test/JobAttributesTest.php
+++ b/test/JobAttributesTest.php
@@ -8,4 +8,27 @@ class JobAttributeTest extends TestCase
     {
         $this->assertSame(1, 1);
     }
+
+    public function testInstantiationWithoutArrayOfAttributes() {
+
+        $jobAttributes = new \obray\ipp\JobAttributes();
+        $jobAttributes->set('page-ranges','1-2');
+
+        $this->assertEquals(new \obray\ipp\types\RangeOfInteger(1,2),$jobAttributes->{'page-ranges'}->getAttributeValueClass());
+
+    }
+
+    public function testInstantiationWithArrayOfAttributes() {
+
+        $attributes = [
+            'job-uri' => 'ipps://www.cups.org/ipp/2234451',
+            'page-ranges' => '3-4'
+        ];
+
+        $jobAttributes = new \obray\ipp\JobAttributes($attributes);
+
+        $this->assertEquals(new \obray\ipp\types\URI('ipps://www.cups.org/ipp/2234451'),$jobAttributes->{'job-uri'}->getAttributeValueClass());
+        $this->assertEquals(new \obray\ipp\types\RangeOfInteger(3,4),$jobAttributes->{'page-ranges'}->getAttributeValueClass());
+
+    }
 }


### PR DESCRIPTION
There are a number of attributes that are useful for the user to set that are currently not allowed when calling Printer->printJob(). For example if a user specifies a 'page-ranges' attribute it will be ignored by the following code in the printJob function:

```
        if(!empty($attributes)){
            $jobAttributes = new \obray\ipp\JobAttributes();
        }
        if(!empty($attributes['media'])){
        	$jobAttributes->{'media'} = $attributes['media'];
        }
        if(!empty($attributes['media-col'])){
            $jobAttributes->{'media-col'} = $attributes['media-col'];
        }
```

I suspect the reason for this was to prevent users specifying invalid attributes when printing but there's a couple problems with this:

1. It will require a lot of duplicated code to set and filter attributes as other printing methods are completed
2. It blocks the use of valid attributes such as page-ranges and orientation
3. The invalid attributes will probably be ignored or cause an error anyway, so filtering them out is not all that useful