### PR TITLE
Fix enum class name JobHoldSheets > JobSheets

### DIFF
--- a/src/enums/JobSheets.php
+++ b/src/enums/JobSheets.php
@@ -2,7 +2,7 @@
 
 namespace obray\ipp\enums;
 
-class JobHoldSheets extends \obray\ipp\types\Enum
+class JobSheets extends \obray\ipp\types\Enum
 {
     const none = "none";
     const standard = "standard";


### PR DESCRIPTION
not sure this is even used any more but this should stop the composer error 

```
Class obray\ipp\enums\JobHoldSheets located in ./vendor/obray/ipp/src/enums/JobSheets.php does not comply with psr-4 autoloading standard. Skipping.
```