### PR TITLE
PHP 8.4 compatiblity

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -12,7 +12,7 @@ class Attribute implements \JsonSerializable
     private $previousNameKey;
     public $attributes = [];
     
-    public function __construct($name=NULL, $value=NULL, int $type=NULL, int $maxLength=NULL, string $naturalLanguage=NULL)
+    public function __construct($name=NULL, $value=NULL, ?int $type=NULL, ?int $maxLength=NULL, ?string $naturalLanguage=NULL)
     {
         if($name===NULL) return $this;
         $this->nameLength = new \obray\ipp\types\basic\SignedShort(strlen($name));

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -109,7 +109,7 @@ class Printer
      * @return \obray\ipp\transport\IPPPayload
      */
 
-    public function validateJob(int $requestId=1, array $attributes=NULL)
+    public function validateJob(int $requestId=1, ?array $attributes=NULL)
     {
         $operationAttributes = new \obray\ipp\OperationAttributes();
         $operationAttributes->{'printer-uri'} = $this->printerURI;
@@ -201,7 +201,7 @@ class Printer
      * @return \obray\ipp\transport\IPPPayload
      */
 
-    public function getJobs(int $requestId = 1, string $whichJobs = null, int $limit = null, bool $myJobs = null)
+    public function getJobs(int $requestId = 1, ?string $whichJobs = null, ?int $limit = null, ?bool $myJobs = null)
     {
         $operationAttributes = new \obray\ipp\OperationAttributes();
         $operationAttributes->{'printer-uri'} = (string)$this->printerURI;

--- a/src/Request.php
+++ b/src/Request.php
@@ -15,7 +15,7 @@ class Request implements \obray\ipp\interfaces\RequestInterface
      * @return \obray\ipp\transport\IPPPayload
      */
 
-    static public function send(string $printerURI, string $encodedPayload, string $user=null, string $password=null, array $curlOptions=[]): \obray\ipp\transport\IPPPayload
+    static public function send(string $printerURI, string $encodedPayload, ?string $user=null, ?string $password=null, array $curlOptions=[]): \obray\ipp\transport\IPPPayload
     {
         // interpret ipp request into http request
         $results = parse_url($printerURI);

--- a/src/interfaces/RequestInterface.php
+++ b/src/interfaces/RequestInterface.php
@@ -3,5 +3,5 @@ namespace obray\ipp\interfaces;
 
 interface RequestInterface
 {
-    public static function send(string $printerURI, string $encodedPayload, string $user=null, string $password=null): \obray\ipp\transport\IPPPayload;
+    public static function send(string $printerURI, string $encodedPayload, ?string $user=null, ?string $password=null): \obray\ipp\transport\IPPPayload;
 }

--- a/src/transport/IPPPayload.php
+++ b/src/transport/IPPPayload.php
@@ -22,14 +22,14 @@ class IPPPayload
     private $document;
 
     public function __construct(
-        \obray\ipp\types\VersionNumber $versionNumber = NULL,
-        \obray\ipp\types\Operation $operation = NULL,
-        \obray\ipp\types\Integer $requestId = NULL,
-        \obray\ipp\types\OctetString $document = NULL,
-        \obray\ipp\OperationAttributes $operationAttributes = NULL,
-        \obray\ipp\JobAttributes $jobAttributes = NULL,
-        \obray\ipp\PrinterAttributes $printerAttributes = NULL,
-        \obray\ipp\UnsupportedAttributes $unsupportedAttributes = NULL)
+        ?\obray\ipp\types\VersionNumber $versionNumber = NULL,
+        ?\obray\ipp\types\Operation $operation = NULL,
+        ?\obray\ipp\types\Integer $requestId = NULL,
+        ?\obray\ipp\types\OctetString $document = NULL,
+        ?\obray\ipp\OperationAttributes $operationAttributes = NULL,
+        ?\obray\ipp\JobAttributes $jobAttributes = NULL,
+        ?\obray\ipp\PrinterAttributes $printerAttributes = NULL,
+        ?\obray\ipp\UnsupportedAttributes $unsupportedAttributes = NULL)
     {
         $this->versionNumber = $versionNumber;
         $this->operation = $operation;


### PR DESCRIPTION
These proposed changes remove deprecation notice caused by PHP 8.4
For example
```
Deprecated: obray\ipp\interfaces\RequestInterface::send(): Implicitly marking parameter $password as nullable is deprecated, the explicit nullable type must be used instead in D:\www_root_vip_rbcb\vendor\obray\ipp\src\interfaces\RequestInterface.php:0
```
